### PR TITLE
Stop camera refresh when a dialog is visible

### DIFF
--- a/motioneye/static/js/main.js
+++ b/motioneye/static/js/main.js
@@ -4932,6 +4932,11 @@ function isFullScreen() {
 function refreshCameraFrames() {
     var timestamp = new Date().getTime();
 
+    if ($('div.modal-container').is(':visible')) {
+        /* pause camera refresh if hidden by a dialog */
+        return setTimeout(refreshCameraFrames, 1000);
+    }
+
     function refreshCameraFrame(cameraId, img, serverSideResize) {
         if (refreshDisabled[cameraId]) {
             /* camera refreshing disabled, retry later */


### PR DESCRIPTION
When dialog is present we are most likely reviewing captured images/movies which can cause a load of thumbnails to be downloaded. If we are capturing and reviewing on a Raspberry Pi 2 or lower then continuing to refresh the camera can cause very slow loading of the thumbnails. Since the camera(s) are at least partially obscured when the dialog is up, then pausing them seems acceptable.